### PR TITLE
github.com/coreos ==> go.etcd.io

### DIFF
--- a/store/etcd/v2/etcd.go
+++ b/store/etcd/v2/etcd.go
@@ -12,9 +12,9 @@ import (
 
 	"golang.org/x/net/context"
 
-	etcd "github.com/coreos/etcd/client"
 	"github.com/docker/libkv"
 	"github.com/docker/libkv/store"
+	etcd "go.etcd.io/etcd/client"
 )
 
 const (

--- a/store/etcd/v3/etcd.go
+++ b/store/etcd/v3/etcd.go
@@ -7,10 +7,10 @@ import (
 	"sync"
 	"time"
 
-	etcd "github.com/coreos/etcd/clientv3"
-	"github.com/coreos/etcd/clientv3/concurrency"
 	"github.com/docker/libkv"
 	"github.com/docker/libkv/store"
+	etcd "go.etcd.io/etcd/clientv3"
+	"go.etcd.io/etcd/clientv3/concurrency"
 )
 
 const (


### PR DESCRIPTION
Changed package paths to meet what k8s expects. golang does not seem to allow different paths to refer to the same code and it is way easier to change this code than changing k8s code everytime we do a kube bump.

Signed-off-by: Vikram bir Singh <vsingh@mirantis.com>