### PR TITLE
enable keepalive for etcd v3

### DIFF
--- a/store/etcd/v3/etcd.go
+++ b/store/etcd/v3/etcd.go
@@ -64,7 +64,10 @@ func New(addrs []string, options *store.Config) (store.Store, error) {
 			setTLS(cfg, options.TLS, addrs)
 		}
 		if options.ConnectionTimeout != 0 {
-			setTimeout(cfg, options.ConnectionTimeout)
+			setDialTimeout(cfg, options.ConnectionTimeout)
+		}
+		if options.PersistConnection {
+			setKeepAlive(cfg)
 		}
 		if options.Username != "" {
 			setCredentials(cfg, options.Username, options.Password)
@@ -89,9 +92,15 @@ func setTLS(cfg *etcd.Config, tls *tls.Config, addrs []string) {
 	cfg.TLS = tls
 }
 
-// setTimeout sets the timeout used for connecting to the store
-func setTimeout(cfg *etcd.Config, time time.Duration) {
+// setDailTimeout sets the timeout used for connecting to the store
+func setDialTimeout(cfg *etcd.Config, time time.Duration) {
 	cfg.DialTimeout = time
+}
+
+// setKeepAlive sets keepalive used for etcd v3
+func setKeepAlive(cfg *etcd.Config) {
+	cfg.DialKeepAliveTime = 30 * time.Second
+	cfg.DialKeepAliveTimeout = 10 * time.Second
 }
 
 // setCredentials sets the username/password credentials for connecting to Etcd


### PR DESCRIPTION
Signed-off-by: Xinfeng Liu <Xinfeng.Liu@gmail.com>

The `keepalive` setting values (`keepaliveTime=30s`, `keepaliveTimeout=10s`) follow [k8s](https://github.com/kubernetes/kubernetes/blob/8f2371bcceff7962ddb4901c36536c6ff659755b/staging/src/k8s.io/apiserver/pkg/storage/storagebackend/factory/etcd3.go#L61-L62), [calico](https://github.com/projectcalico/calico/blob/8ae1e82d05c26c5b4a72e718fd1130a41aa8a5a6/libcalico-go/lib/backend/etcdv3/etcdv3.go#L42-L43) also uses the same setting values.